### PR TITLE
Fixing issue with GPG key conflicts if defined in multiple places.

### DIFF
--- a/manifests/job.pp
+++ b/manifests/job.pp
@@ -69,9 +69,9 @@ define duplicity::job(
     default => "${pre_command} && "
   }
 
-  $_encryption = $pubkey_id ? {
+  $_encryption = $_pubkey_id ? {
     undef => '--no-encryption',
-    default => "--encrypt-key ${pubkey_id}"
+    default => "--encrypt-key ${_pubkey_id}"
   }
 
   $_remove_older_than = $remove_older_than ? {
@@ -132,7 +132,7 @@ define duplicity::job(
     mode    => '0700',
   }
 
-  if $_pubkey_id {
+  if ($_pubkey_id and !defined(Duplicity::Gpg[$_pubkey_id])){
     @duplicity::gpg{ $_pubkey_id: }
   }
 }

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -11,8 +11,6 @@ class duplicity::params(
   $job_spool = $duplicity::defaults::job_spool
 ) inherits duplicity::defaults {
 
-  @duplicity::gpg{ $pubkey_id: }
-
   Duplicity::Gpg <| |>
 
   file { $job_spool :


### PR DESCRIPTION
- Removed GPG virtual resource definition from params because it's unnecessary
- Fixed bug with use of $pubkey instead of $_pubkey
- Added a check to the GPG definition to ensure the GPG key is only defined once
