### PR TITLE
cronjob should not always exit with a zero exit code

### DIFF
--- a/manifests/job.pp
+++ b/manifests/job.pp
@@ -64,11 +64,6 @@ define duplicity::job(
     default => $full_if_older_than
   }
 
-  $_pre_command = $pre_command ? {
-    undef => '',
-    default => "${pre_command} && "
-  }
-
   $_encryption = $_pubkey_id ? {
     undef => '--no-encryption',
     default => "--encrypt-key ${_pubkey_id}"

--- a/spec/defines/job_spec.rb
+++ b/spec/defines/job_spec.rb
@@ -30,6 +30,11 @@ describe 'duplicity::job' do
       .with_mode('0700')
   end
 
+  it "should exit with a non-zero exit code in case of errors during the duplicity job / pre-command so that e. g. cron monitors are alarmed if something went wrong" do
+    should contain_file(spoolfile) \
+      .with_content(/^set -e$/)\
+  end
+
   context "cloud files environment" do
 
     let(:params) {
@@ -213,7 +218,7 @@ describe 'duplicity::job' do
 
     it "should prepend pre_command to cronjob" do
       should contain_file(spoolfile) \
-        .with_content(/^mysqldump database && /)
+        .with_content(/\nmysqldump database\n.*duplicity/m)
     end
   end
 

--- a/templates/file-backup.sh.erb
+++ b/templates/file-backup.sh.erb
@@ -11,7 +11,7 @@ trap "" HUP WINCH
 <% @_environment.each do |key,value|-%>
 export <%= key -%>='<%= value -%>'
 <% end-%>
-<%= @_pre_command %>
+<%= @pre_command %>
 duplicity --full-if-older-than <%= @_full_if_older_than -%> --s3-use-new-style <%= @_encryption -%> --include '<%= @directory -%>' --exclude '**' / <%= @_target_url -%>
 <%= @_remove_older_than_command %>
 


### PR DESCRIPTION
should exit non-zero in case of errors during the duplicity job so that e. g.
cron monitors are alarmed if something went wrong.
