### PR TITLE
catch all duplicity errors and exit accordingly

### DIFF
--- a/templates/file-backup.sh.erb
+++ b/templates/file-backup.sh.erb
@@ -17,4 +17,10 @@ export <%= key -%>='<%= value -%>'
 duplicity --full-if-older-than <%= @_full_if_older_than -%> --s3-use-new-style <%= @_encryption -%> <%= @directory.map { |dir| "--include '#{dir}'" }.join " " -%> --exclude '**' / <%= @_target_url -%>
 <%= @_remove_older_than_command %>
 
+duplicity_exit_code=$?
+if [ $duplicity_exit_code -ne 0 ]; then
+    echo "duplicity exited with exit code: $duplicity_exit_code"
+    exit 2
+fi
+
 exit 0


### PR DESCRIPTION
before this, the script exits with 0 even though duplicity exits with an error code of 3:
```
Fatal Error: Backup source host has changed.
Current hostname: XXX
Previous hostname: XXY

Aborting because you may have accidentally tried to backup two different data sets to the same remote location, or using the same archive directory.  If this is not a mistake, use the --allow-source-mismatch switch to avoid seeing this message
3
```