### PR TITLE
fix error handling when removing old backups

### DIFF
--- a/manifests/job.pp
+++ b/manifests/job.pp
@@ -112,7 +112,7 @@ define duplicity::job(
 
   $_remove_older_than_command = $_remove_older_than ? {
     undef => '',
-    default => " && duplicity remove-older-than ${_remove_older_than} --s3-use-new-style ${_encryption} --force ${_target_url}"
+    default => "duplicity remove-older-than ${_remove_older_than} --s3-use-new-style ${_encryption} --force ${_target_url}"
   }
 
   file { $spoolfile:

--- a/spec/defines/job_spec.rb
+++ b/spec/defines/job_spec.rb
@@ -131,7 +131,7 @@ describe 'duplicity::job' do
 
     it "should be able to handle a specified remove-older-than time" do
       should contain_file(spoolfile) \
-        .with_content(/remove-older-than 7D.* --no-encryption --force.*/)
+        .with_content(/^duplicity remove-older-than 7D.* --no-encryption --force.*/)
     end
   end
 

--- a/templates/file-backup.sh.erb
+++ b/templates/file-backup.sh.erb
@@ -14,7 +14,7 @@ export <%= key -%>='<%= value -%>'
 <%  end -%>
 <% end-%>
 <%= @pre_command %>
-duplicity --full-if-older-than <%= @_full_if_older_than -%> --s3-use-new-style <%= @_encryption -%> <%= @directory.map { |dir| "--include '#{dir}'" }.join " " -%> --exclude '**' / <%= @_target_url -%>
+duplicity --full-if-older-than <%= @_full_if_older_than -%> --s3-use-new-style <%= @_encryption -%> <%= @directory.map { |dir| "--include '#{dir}'" }.join " " -%> --exclude '**' / <%= @_target_url %>
 <%= @_remove_older_than_command %>
 
 exit 0


### PR DESCRIPTION
traps don't handle statements when chained with &&.
as we are using -e it is ok to run removal job in an extra line because the script exits when duplicity backup fails anyway