### PR TITLE
add optional log file to cron job

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -12,6 +12,7 @@ define duplicity(
   $full_if_older_than = undef,
   $pre_command = undef,
   $remove_older_than = undef,
+  $logfile = undef,
 ) {
 
   include duplicity::params
@@ -45,9 +46,19 @@ define duplicity(
     default => $minute
   }
 
+  $_logfile = $logfile ? {
+    undef   => $duplicity::params::logfile,
+    default => $logfile
+  }
+
+  $_croncommand = $_logfile ? {
+    undef   => $spoolfile,
+    default => "${spoolfile} >>${_logfile} 2>&1"
+  }
+
   cron { $name :
     ensure  => $ensure,
-    command => $spoolfile,
+    command => $_croncommand,
     user    => 'root',
     minute  => $_minute,
     hour    => $_hour,

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -9,6 +9,7 @@ class duplicity::params(
   $full_if_older_than    = $duplicity::defaults::full_if_older_than,
   $remove_older_than     = undef,
   $allow_source_mismatch = undef,
+  $logfile               = undef,
   $job_spool = $duplicity::defaults::job_spool
 ) inherits duplicity::defaults {
 

--- a/spec/defines/duplicity_spec.rb
+++ b/spec/defines/duplicity_spec.rb
@@ -60,6 +60,25 @@ describe 'duplicity', :type => :define do
     end
   end
 
+  context "with defined logfile" do
+    let(:command_with_log) { "#{spoolfile} >>/var/log/duplicity.log 2>&1" }
+
+    let(:params) {
+      {
+        :bucket       => 'somebucket',
+        :directory    => '/etc/',
+        :dest_id      => 'some_id',
+        :dest_key     => 'some_key',
+        :logfile      => '/var/log/duplicity.log'
+      }
+    }
+
+    it "should be able to handle a specified logfile" do
+       should contain_cron(title) \
+         .with_command(command_with_log)
+    end
+  end
+
   context 'with duplicity global parameters passed on' do
     let(:params) {
       {


### PR DESCRIPTION
Adding an optional logfile parameter that if set will add $logfile to the cron job command using sensible parameters (>> file 2>&1). This also allows no logging or cron email by setting logfile to /dev/null.
